### PR TITLE
allow CS agents to backdoor directly from *611 instead of running backdoor in another channel

### DIFF
--- a/Commands/Call/backdoor.js
+++ b/Commands/Call/backdoor.js
@@ -1,0 +1,7 @@
+module.exports = async(client, msg, suffix, call) => {
+	if (!msg.author.support || !call.pickedUp) return;
+	if (msg.channel.id != config.supportChannel) return msg.channel.send({ embed: { color: config.colors.error, title: "Permission error", description: "You are only allowed to do this command from the `*611` channel." } });
+	if (!suffix) msg.channel.send({ embed: { color: config.colors.info, title: "Command usage", description: ">backdoor" } });
+
+	require("../Support/backdoor.js")(client, msg, await call.to.number.toString());
+};

--- a/Commands/Call/backdoor.js
+++ b/Commands/Call/backdoor.js
@@ -1,7 +1,6 @@
 module.exports = async(client, msg, suffix, call) => {
 	if (!msg.author.support || !call.pickedUp) return;
-	if (msg.channel.id != config.supportChannel) return msg.channel.send({ embed: { color: config.colors.error, title: "Permission error", description: "You can’t use this command outside of `*611` calls." } });
-	if (!suffix) msg.channel.send({ embed: { color: config.colors.info, title: "Command usage", description: ">backdoor" } });
+	if (msg.channel.id !== config.supportChannel) return msg.channel.send({ embed: { color: config.colors.error, title: "Permission error", description: "You can’t use this command outside of `*611` calls." } });
 
-	require("../Support/backdoor.js")(client, msg, await call.to.number.toString());
+	require("../Support/backdoor.js")(client, msg, call.from.number === (await msg.channel.number) ? call.to.number : call.from.number);
 };

--- a/Commands/Call/backdoor.js
+++ b/Commands/Call/backdoor.js
@@ -1,6 +1,6 @@
 module.exports = async(client, msg, suffix, call) => {
 	if (!msg.author.support || !call.pickedUp) return;
-	if (msg.channel.id != config.supportChannel) return msg.channel.send({ embed: { color: config.colors.error, title: "Permission error", description: "You are only allowed to do this command from the `*611` channel." } });
+	if (msg.channel.id != config.supportChannel) return msg.channel.send({ embed: { color: config.colors.error, title: "Permission error", description: "You can’t use this command outside of `*611` calls." } });
 	if (!suffix) msg.channel.send({ embed: { color: config.colors.info, title: "Command usage", description: ">backdoor" } });
 
 	require("../Support/backdoor.js")(client, msg, await call.to.number.toString());

--- a/Commands/Call/backdoor.js
+++ b/Commands/Call/backdoor.js
@@ -2,5 +2,5 @@ module.exports = async(client, msg, suffix, call) => {
 	if (!msg.author.support || !call.pickedUp) return;
 	if (msg.channel.id !== config.supportChannel) return msg.channel.send({ embed: { color: config.colors.error, title: "Permission error", description: "You can’t use this command outside of `*611` calls." } });
 
-	require("../Support/backdoor.js")(client, msg, call.from.number === (await msg.channel.number) ? call.to.number : call.from.number);
+	require("../Support/backdoor.js")(client, msg, call.from.number === (await msg.channel.number).id ? call.to.number : call.from.number);
 };


### PR DESCRIPTION
just something to allow customer support agents to easily gain access to another channel/guild if/when necessary so they dont have to backdoor thru another channel