### PR TITLE
fix formatting when message is edited

### DIFF
--- a/Events/messageUpdate.js
+++ b/Events/messageUpdate.js
@@ -31,7 +31,7 @@ module.exports = async(omsg, nmsg) => {
 	if (!hidden) for (let perm in config.callPhones) if (perms[perm]) phone = config.callPhones[perm];
 
 	let toCSChannel = editChannel === config.supportChannel;
-	let toSend = `**${hidden ? "Anonymous#0000" : nmsg.author.tag}${toCSChannel ? `(${nmsg.author.id})` : ""} [edited]** ${phone} ${nmsg.content}`;
+	let toSend = `**${hidden ? "Anonymous#0000" : nmsg.author.tag}${toCSChannel ? ` (${nmsg.author.id})` : ""} [edited]** ${phone} ${nmsg.content}`;
 	let edited = await client.apiEdit(toSend, editChannel, message.dtelmsg);
 	if (!edited.id) {
 		await client.apiSend(`${toSend}`, editChannel);


### PR DESCRIPTION
edited: Scottus#4270(327914943804473345) [edited] 
correct: Scottus#4270 (327914943804473345)
user id is separated by a space in the correct one, meanwhile the edited one does not have it and it hurts my eyes

this change fixes it
and this change makes eyes better